### PR TITLE
simple fix

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -617,7 +617,9 @@ func (b *Broker) removeClient(c *client) {
 func (b *Broker) PublishMessage(packet *packets.PublishPacket) {
 	var subs []interface{}
 	var qoss []byte
+	b.mu.Lock()
 	err := b.topicsMgr.Subscribers([]byte(packet.TopicName), packet.Qos, &subs, &qoss)
+	b.mu.Unlock()
 	if err != nil {
 		log.Error("search sub client error,  ", zap.Error(err))
 		return

--- a/broker/client.go
+++ b/broker/client.go
@@ -213,7 +213,9 @@ func (c *client) ProcessPublishMessage(packet *packets.PublishPacket) {
 		}
 	}
 
+	c.mu.Lock()
 	err := c.topicsMgr.Subscribers([]byte(packet.TopicName), packet.Qos, &c.subs, &c.qoss)
+	c.mu.Unlock()
 	if err != nil {
 		log.Error("Error retrieving subscribers list: ", zap.String("ClientID", c.info.clientID))
 		return


### PR DESCRIPTION
Heya! 

I've found that `topicsMgr.Subscribers(...)` can leads to unpredictable subs listing in high concurrent scenario. Seems that a simple lock sort that out. Please have a look if you can think of a better way.
Regards!