### PR TITLE
do not expect "Origin" header for websocket connections

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -155,7 +155,8 @@ func (b *Broker) StartWebsocketListening() {
 	path := b.config.WsPath
 	hp := ":" + b.config.WsPort
 	log.Info("Start Websocket Listener on:", zap.String("hp", hp), zap.String("path", path))
-	http.Handle(path, websocket.Handler(b.wsHandler))
+	ws := &websocket.Server{Handler: websocket.Handler(b.wsHandler)}
+	http.Handle(path, ws)
 	var err error
 	if b.config.WsTLS {
 		err = http.ListenAndServeTLS(hp, b.config.TlsInfo.CertFile, b.config.TlsInfo.KeyFile, nil)

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -156,12 +156,13 @@ func (b *Broker) StartWebsocketListening() {
 	hp := ":" + b.config.WsPort
 	log.Info("Start Websocket Listener on:", zap.String("hp", hp), zap.String("path", path))
 	ws := &websocket.Server{Handler: websocket.Handler(b.wsHandler)}
-	http.Handle(path, ws)
+	mux := http.NewServeMux()
+	mux.Handle(path, ws)
 	var err error
 	if b.config.WsTLS {
-		err = http.ListenAndServeTLS(hp, b.config.TlsInfo.CertFile, b.config.TlsInfo.KeyFile, nil)
+		err = http.ListenAndServeTLS(hp, b.config.TlsInfo.CertFile, b.config.TlsInfo.KeyFile, mux)
 	} else {
-		err = http.ListenAndServe(hp, nil)
+		err = http.ListenAndServe(hp, mux)
 	}
 	if err != nil {
 		log.Error("ListenAndServe:" + err.Error())


### PR DESCRIPTION
By default, the websocket library checks whether there is an `Origin` header in the very first HTTP request. This is pointless unless you check the contents of this header. It is even in the way when the requests do not come from browsers. (I used the mqtt client from hivemq- https://hivemq.github.io/mqtt-cli/ for testing. It has a websockets mode.)

While I was at this, I also figured that the code uses the global variable `http.DefaultServeMux`. This could be problematic when the broker is included into a larger server as library. Instead, a local mux is created for serving websocket requests.