### PR TITLE
only set a read deadline when the keep-alive value is positive

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -121,14 +121,16 @@ func (c *client) readLoop() {
 			return
 		default:
 			//add read timeout
-			if err := nc.SetReadDeadline(time.Now().Add(timeOut)); err != nil {
-				log.Error("set read timeout error: ", zap.Error(err), zap.String("ClientID", c.info.clientID))
-				msg := &Message{
-					client: c,
-					packet: DisconnectdPacket,
+			if keepAlive > 0 {
+				if err := nc.SetReadDeadline(time.Now().Add(timeOut)); err != nil {
+					log.Error("set read timeout error: ", zap.Error(err), zap.String("ClientID", c.info.clientID))
+					msg := &Message{
+						client: c,
+						packet: DisconnectdPacket,
+					}
+					b.SubmitWork(c.info.clientID, msg)
+					return
 				}
-				b.SubmitWork(c.info.clientID, msg)
-				return
 			}
 
 			packet, err := packets.ReadPacket(nc)


### PR DESCRIPTION
According to the MQTT-3.1.1 spec: "A Keep Alive value of zero (0) has the effect of turning off the keep alive mechanism." (section 3.1.2.10). This can also be useful for local connections as it reduces the surface for implementation errors.