### PR TITLE
Bugfix - authfile plugin did wrongly use username as IP and IP as username in ACL checks

### DIFF
--- a/plugins/auth/authfile/acl.go
+++ b/plugins/auth/authfile/acl.go
@@ -19,5 +19,6 @@ func (a *aclAuth) CheckConnect(clientID, username, password string) bool {
 }
 
 func (a *aclAuth) CheckACL(action, clientID, username, ip, topic string) bool {
-	return checkTopicAuth(a.config, action, username, ip, clientID, topic)
+	// checkTopicAuth(ACLInfo *ACLConfig, action, ip, username, clientid, topic string) bool {
+	return checkTopicAuth(a.config, action, ip, username, clientID, topic)
 }

--- a/plugins/auth/authfile/acl.go
+++ b/plugins/auth/authfile/acl.go
@@ -19,6 +19,5 @@ func (a *aclAuth) CheckConnect(clientID, username, password string) bool {
 }
 
 func (a *aclAuth) CheckACL(action, clientID, username, ip, topic string) bool {
-	// checkTopicAuth(ACLInfo *ACLConfig, action, ip, username, clientid, topic string) bool {
 	return checkTopicAuth(a.config, action, ip, username, clientID, topic)
 }

--- a/plugins/auth/authfile/acl_test.go
+++ b/plugins/auth/authfile/acl_test.go
@@ -3,7 +3,6 @@
 package acl
 
 import (
-	"bufio"
 	"os"
 	"testing"
 
@@ -21,31 +20,4 @@ func TestOrigAcls(t *testing.T) {
 	assert.True(t, origAllowed)
 	origAllowed = aclOrig.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "$SYS/something")
 	assert.False(t, origAllowed)
-}
-
-func TestInitWithConfig(t *testing.T) {
-	// lets create the same config (default) and the one created separately and check that the support similar auth procedures
-
-	pwd, _ := os.Getwd()
-	os.Chdir("../../../")
-	aclOrig := Init()
-	os.Chdir(pwd)
-
-	// read the same from the file (for testing purpose) and use the newly offered way to read config from the reader (= from memory)
-	f, err := os.Open("./acl.conf")
-	if assert.NoError(t, err) {
-		buf := bufio.NewReader(f)
-
-		aclConfig := &ACLConfig{}
-		aclConfig.PraseFromReader(buf)
-		aclNew := InitWithConfig(aclConfig)
-
-		assert.Equal(t, aclOrig.CheckConnect("dummyClientID", "dummyUser", "dummyPsw"), aclNew.CheckConnect("dummyClientID", "dummyUser", "dummyPsw"))
-		origAllowed := aclOrig.CheckACL(PUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
-		newAllowed := aclNew.CheckACL(PUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
-		assert.Equal(t, origAllowed, newAllowed)
-		origAllowed = aclOrig.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
-		newAllowed = aclNew.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
-		assert.Equal(t, origAllowed, newAllowed)
-	}
 }

--- a/plugins/auth/authfile/acl_test.go
+++ b/plugins/auth/authfile/acl_test.go
@@ -1,0 +1,51 @@
+//+build test
+
+package acl
+
+import (
+	"bufio"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrigAcls(t *testing.T) {
+	pwd, _ := os.Getwd()
+	os.Chdir("../../../")
+	aclOrig := Init()
+	os.Chdir(pwd)
+
+	// rule: allow      ip          127.0.0.1      2         $SYS/#
+	origAllowed := aclOrig.CheckACL(PUB, "dummyClientID", "dummyUser", "127.0.0.1", "$SYS/something")
+	assert.True(t, origAllowed)
+	origAllowed = aclOrig.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "$SYS/something")
+	assert.False(t, origAllowed)
+}
+
+func TestInitWithConfig(t *testing.T) {
+	// lets create the same config (default) and the one created separately and check that the support similar auth procedures
+
+	pwd, _ := os.Getwd()
+	os.Chdir("../../../")
+	aclOrig := Init()
+	os.Chdir(pwd)
+
+	// read the same from the file (for testing purpose) and use the newly offered way to read config from the reader (= from memory)
+	f, err := os.Open("./acl.conf")
+	if assert.NoError(t, err) {
+		buf := bufio.NewReader(f)
+
+		aclConfig := &ACLConfig{}
+		aclConfig.PraseFromReader(buf)
+		aclNew := InitWithConfig(aclConfig)
+
+		assert.Equal(t, aclOrig.CheckConnect("dummyClientID", "dummyUser", "dummyPsw"), aclNew.CheckConnect("dummyClientID", "dummyUser", "dummyPsw"))
+		origAllowed := aclOrig.CheckACL(PUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
+		newAllowed := aclNew.CheckACL(PUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
+		assert.Equal(t, origAllowed, newAllowed)
+		origAllowed = aclOrig.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
+		newAllowed = aclNew.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "toDevice/dummyClientID")
+		assert.Equal(t, origAllowed, newAllowed)
+	}
+}


### PR DESCRIPTION
I wanted to create an extension to the authfile plugin to load config from a reader instead from a file. While testing it I realized that the aclAuth function CheckACL uses parameter order ... username, ip ... where the checkTopicAuth function uses ... ip, username ...

The result is that the included sample config is not correctly working when writing a test against it.