### PR TITLE
Packet fields validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ log
 log/*
 *.test
 .vscode/settings.json
+.pre-commit-config.yaml


### PR DESCRIPTION
Issue #104 

This PR implements the following rules:

Reference: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.pdf

_The character data in a UTF-8 encoded string MUST be well-formed UTF-8 as defined by the Unicode
specification [Unicode] and restated in RFC 3629 [RFC3629]. In particular this data MUST NOT include
encodings of code points between U+D800 and U+DFFF. If a Server or Client receives a Control Packet
containing ill-formed UTF-8 it MUST close the Network Connection [MQTT-1.5.3-1]._

_A UTF-8 encoded string MUST NOT include an encoding of the null character U+0000. If a receiver
(Server or Client) receives a Control Packet containing U+0000 it MUST close the Network
Connection [MQTT-1.5.3-2]._