### PR TITLE
Adds nil check for subscription/topic-mngr at client Close()

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -794,6 +794,10 @@ func (c *client) Close() {
 	if b != nil {
 		b.removeClient(c)
 		for _, sub := range subs {
+			// guard against race condition where a client gets Close() but wasn't initialized yet fully
+			if sub == nil || b.topicsMgr == nil {
+				continue
+			}
 			err := b.topicsMgr.Unsubscribe([]byte(sub.topic), sub)
 			if err != nil {
 				log.Error("unsubscribe error, ", zap.Error(err), zap.String("ClientID", c.info.clientID))


### PR DESCRIPTION
During runtime we encountered an error with a fast disconnecting client (I assume that's the problem) which resulted in a nil pointer error:

```
{"level":"warn","timestamp":"2021-03-17T14:41:10.988+0100","logger":"broker","caller":"broker/broker.go:348","msg":"client exist, close old...","clientID":"api.hornet-0.testnet.chrysalis2.com"}
{"level":"error","timestamp":"2021-03-17T14:41:10.988+0100","logger":"broker","caller":"broker/client.go:174","msg":"read packet error: ","error":"read tcp 172.18.0.3:1883->20.190.228.100:1156: use of closed network connection","ClientID":"api.hornet-0.testnet.chrysalis2.com"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x13e82d7]

goroutine 166999 [running]:
github.com/fhmq/hmq/broker.(*client).Close(0xc001478300)
        /go/pkg/mod/github.com/fhmq/hmq@v0.0.0-20210226074401-7cc3949bbe89/broker/client.go:797 +0x1f7
github.com/fhmq/hmq/broker.(*Broker).handleConnection(0xc0003484b0, 0x0, 0x20ac470, 0xc000115730)
        /go/pkg/mod/github.com/fhmq/hmq@v0.0.0-20210226074401-7cc3949bbe89/broker/broker.go:351 +0x119a
created by github.com/fhmq/hmq/broker.(*Broker).StartClientListening
        /go/pkg/mod/github.com/fhmq/hmq@v0.0.0-20210226074401-7cc3949bbe89/broker/broker.go:220 +0xad1
```