### PR TITLE
client disconnect fixed

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -180,6 +180,12 @@ func (c *client) readLoop() {
 				return
 			}
 
+			// if packet is disconnect from client, then need to break the read packet loop and clear will msg.
+			if _, isDisconnect := packet.(*packets.DisconnectPacket); isDisconnect {
+				c.info.willMsg = nil
+				c.cancelFunc()
+			}
+
 			msg := &Message{
 				client: c,
 				packet: packet,


### PR DESCRIPTION
If receive a client disconnect pack:
1.Then need to break the read packet loop before next loop start, to avoid a IO error.
2.To clear will msg, according to MQTT 3.1.1: "The Will Message MUST be published when the Network Connection is subsequently closed **unless** the Will Message has been deleted by the Server on receipt of a **DISCONNECT Packet**".