### PR TITLE
docker: use ENTRYPOINT so command line args can get passed into container when executed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /
 COPY --from=builder /go/src/github.com/fhmq/hmq/hmq .
 EXPOSE 1883
 
-CMD ["/hmq"]
+ENTRYPOINT ["/hmq"]


### PR DESCRIPTION
This PR modifies the Dockerfile to use `ENTRYPOINT` so that command line args can get passed into container when executed.

For example:

```
docker build -t hmq:latest .
docker run hmq:latest -p 1883
```