### PR TITLE
Isolate separate brokers and prevent sharing messages between them

### DIFF
--- a/broker/lib/sessions/memprovider.go
+++ b/broker/lib/sessions/memprovider.go
@@ -8,7 +8,7 @@ import (
 var _ SessionsProvider = (*memProvider)(nil)
 
 func init() {
-	Register("mem", NewMemProvider())
+	Register("mem", func() SessionsProvider { return NewMemProvider() })
 }
 
 type memProvider struct {

--- a/broker/lib/topics/memtopics.go
+++ b/broker/lib/topics/memtopics.go
@@ -30,7 +30,7 @@ type memTopics struct {
 }
 
 func init() {
-	Register("mem", NewMemProvider())
+	Register("mem", func() TopicsProvider { return NewMemProvider() })
 }
 
 // NewMemProvider returns an new instance of the memTopics, which is implements the

--- a/broker/lib/topics/topics.go
+++ b/broker/lib/topics/topics.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	providers = make(map[string]TopicsProvider)
+	providers = make(map[string]func() TopicsProvider)
 )
 
 // TopicsProvider
@@ -37,16 +37,16 @@ type TopicsProvider interface {
 	Close() error
 }
 
-func Register(name string, provider TopicsProvider) {
-	if provider == nil {
-		panic("topics: Register provide is nil")
+func Register(name string, providerFn func() TopicsProvider) {
+	if providerFn == nil {
+		panic("topics: Register provider is nil")
 	}
 
 	if _, dup := providers[name]; dup {
 		panic("topics: Register called twice for provider " + name)
 	}
 
-	providers[name] = provider
+	providers[name] = providerFn
 }
 
 func Unregister(name string) {
@@ -63,7 +63,7 @@ func NewManager(providerName string) (*Manager, error) {
 		return nil, fmt.Errorf("session: unknown provider %q", providerName)
 	}
 
-	return &Manager{p: p}, nil
+	return &Manager{p: p()}, nil
 }
 
 func (this *Manager) Subscribe(topic []byte, qos byte, subscriber interface{}) (byte, error) {


### PR DESCRIPTION
### Issue
Separately initialized brokers that use the same topics will share messages between them. The underlying topic and session management is not isolated on construction of new brokers.

I noticed this when building a service that runs multiple brokers with the same topic name but different ports. My (reasonable?) expectation was that these separate brokers would be isolated.

See repro of this issue in this [gist](https://gist.github.com/elh/bbe5b7bd30682e58dd2a11e4baf63e5f). (I just wasn't sure how Github would handle a large text dump in a PR comment. Can add later if people prefer.)

### Proposal
 instantiate new TopicProvider and SessionsProvider on topics.NewManager() and sessions.NewManager() call