### PR TITLE
Added in GET /connections to update restarting node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ log/*
 .vscode/settings.json
 .pre-commit-config.yaml
 hmq.exe
+*.sw*
+*.swo
+*.swp
+*.swn


### PR DESCRIPTION
During a temporary service re-hydration, this allows the recovering service to:

1.) Sub to /connections for all incoming connections then
2.) Get a list of all connections that exist rn.

This is useful for rebuilding caches and if any of your edge-workers need to be restarted, they can. It also allows for you not to have a 100% coupling in Redis or any other MQ stream. There are still no routes for the MQ streams to get all conns on connect, when we migrate to this we will add in this support as well.

Also cleaned up some routing patters in Gin, added in some constants to make it cleaner to add a lot of REST routes later.

Also added in new type "resp" to push down the values over json, use the omitempty tag to tell encoding/json to ignore this field.

Pro tip: if you have a struct nested in an omitempty field and you don't want it to be serialized. Make it a * golang by default treats these as "nil" and won't serialize them if they are not defined