### PR TITLE
rm a redundant creation of goroutines

### DIFF
--- a/pool/fixpool.go
+++ b/pool/fixpool.go
@@ -43,16 +43,14 @@ func (p *WorkerPool) dispatch() {
 }
 
 func startWorker(taskChan chan func()) {
-	go func() {
-		var task func()
-		var ok bool
-		for {
-			task, ok = <-taskChan
-			if !ok {
-				break
-			}
-			// Execute the task.
-			task()
+	var task func()
+	var ok bool
+	for {
+		task, ok = <-taskChan
+		if !ok {
+			break
 		}
-	}()
+		// Execute the task.
+		task()
+	}
 }


### PR DESCRIPTION
```
func (p *WorkerPool) dispatch() {
	for i := 0; i < p.maxWorkers; i++ {
		p.taskQueue[i] = make(chan func(), 1024)
		go startWorker(p.taskQueue[i])
	}
}
```
since function *dispatch* execute *startWorker* by goroutine, there is no need for *startWorker* to use goroutine inside.