### PR TITLE
HOTFIX | Fixed pubMsg when WillTopic is null

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -407,7 +407,6 @@ func (b *Broker) handleConnection(typ int, conn net.Conn) error{
 			}
 		}
 		b.clients.Store(cid, c)
-		log.Warn("trying to build publish packet..\n")
 
 		var pubPack = PubPacket{}
 		if willmsg != nil {

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -407,16 +407,20 @@ func (b *Broker) handleConnection(typ int, conn net.Conn) error{
 			}
 		}
 		b.clients.Store(cid, c)
+		log.Warn("trying to build publish packet..\n")
+
+		var pubPack = PubPacket{}
+		if willmsg != nil {
+			pubPack.TopicName = info.willMsg.TopicName
+			pubPack.Payload = info.willMsg.Payload
+		}
 		
 		pubInfo := Info{
 			ClientID: info.clientID,
 			Username: info.username,
 			Password: info.password,
 			Keepalive: info.keepalive,
-			WillMsg: &PubPacket{
-				TopicName: info.willMsg.TopicName,
-				Payload: info.willMsg.Payload,
-			},
+			WillMsg: pubPack,
 		}
 
 		b.OnlineOfflineNotification(pubInfo, true, c.lastMsgTime)

--- a/broker/client.go
+++ b/broker/client.go
@@ -122,7 +122,7 @@ type Info struct {
 	Username  string			`json:"username"`
 	Password  []byte			`json:"password"`
 	Keepalive uint16			`json:"keepalive"`
-	WillMsg   *PubPacket			`json:"willMsg"`
+	WillMsg   PubPacket			`json:"willMsg"`
 }
 
 type route struct {
@@ -859,15 +859,19 @@ func (c *client) Close() {
 
 	if c.typ == CLIENT {
 		b.BroadcastUnSubscribe(unSubTopics)
+
+		var pubPack = PubPacket{}
+		if c.info.willMsg != nil {
+			pubPack.TopicName = c.info.willMsg.TopicName
+			pubPack.Payload = c.info.willMsg.Payload
+		}
+
 		pubInfo := Info{
 			ClientID: c.info.clientID,
 			Username: c.info.username,
 			Password: c.info.password,
 			Keepalive: c.info.keepalive,
-			WillMsg: &PubPacket{
-				TopicName: c.info.willMsg.TopicName,
-				Payload: c.info.willMsg.Payload,
-			},
+			WillMsg: pubPack,
 		}
 		//offline notification
 		b.OnlineOfflineNotification(pubInfo, false, c.lastMsgTime)

--- a/broker/http.go
+++ b/broker/http.go
@@ -37,6 +37,11 @@ func InitHTTPMoniter(b *Broker) {
 		conns := make([]ConnClient, 0)
 		b.clients.Range(func (k, v interface{}) bool {
 			cl, _ := v.(*client)
+			var pubPack = PubPacket{}
+			if cl.info.willMsg != nil {
+				pubPack.TopicName = cl.info.willMsg.TopicName
+				pubPack.Payload = cl.info.willMsg.Payload
+			}
 
 			msg := ConnClient{
 				Info: Info{
@@ -44,10 +49,7 @@ func InitHTTPMoniter(b *Broker) {
 					Username: cl.info.username,
 					Password: cl.info.password,
 					Keepalive: cl.info.keepalive,
-					WillMsg: &PubPacket{
-						TopicName: cl.info.willMsg.TopicName,
-						Payload: cl.info.willMsg.Payload,
-					},
+					WillMsg: pubPack,
 				},
 				LastMsgTime: cl.lastMsgTime,
 			}


### PR DESCRIPTION
Runtime issue wasn't previously handled when the WillTopic was null, Go's compiler wouldn't care but it would throw a runtime error if there was no Last Will set. We should consider adding in a unit test system to properly catch this next time.

@chowyu12 can you please upstream this and tag a new release like v1.5.2 with the hot fix?