### PR TITLE
fix(broker):Added file removal for unix sock communication #203

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -285,6 +285,7 @@ func (b *Broker) StartUnixSocketClientListening(socketPath string, unixSocket bo
 		if unixSocket {
 			if FileExist(socketPath) {
 				if err != nil {
+					err = os.Remove(socketPath)
 					log.Error("Remove Unix socketPath ", zap.Error(err))
 				}
 			}

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -284,8 +284,8 @@ func (b *Broker) StartUnixSocketClientListening(socketPath string, unixSocket bo
 	for {
 		if unixSocket {
 			if FileExist(socketPath) {
+				err = os.Remove(socketPath)
 				if err != nil {
-					err = os.Remove(socketPath)
 					log.Error("Remove Unix socketPath ", zap.Error(err))
 				}
 			}


### PR DESCRIPTION
I need to fix the file removal function of unixsocket, if not removed, it will cause the sock file to be occupied every time you start，We sincerely hope that the author can re-issue a new version for our use